### PR TITLE
Use the fullName() method on the password reminder email

### DIFF
--- a/Web Applications/TeamMentor.CoreLib/TM_AppCode/Utils/SendEmails.cs
+++ b/Web Applications/TeamMentor.CoreLib/TM_AppCode/Utils/SendEmails.cs
@@ -147,7 +147,7 @@ var userMessage =
 
 You can change the password of your {1} account using {3}/passwordReset/{1}/{2}
 
-If you didn't make this request, please let us know at support@teammentor.net.
+If you didn't make this request, please let us know at support@securityinnovation.com.
              ".format(tmUser.fullName(), tmUser.UserName, passwordResetToken,TM_Server_URL);
              
                 SendEmailToEmail(tmUser.EMail, "TeamMentor Password Reset", userMessage);


### PR DESCRIPTION
Fixes cases where first and last name don't have valid values as reported on:  https://github.com/TeamMentor/Master/issues/511
