### PR TITLE
Fixing issue 384

### DIFF
--- a/Web Applications/TM_Website/Html_Pages/Gui/Dialogs/Change_Password.html
+++ b/Web Applications/TM_Website/Html_Pages/Gui/Dialogs/Change_Password.html
@@ -30,10 +30,12 @@
                     
                     var currentPassword = $("#CurrentPassword").value();
                     var password        = $("#Password").value();
-                    var passwordConfirm = $("#PasswordConfirm").value();								
+                    var passwordConfirm = $("#PasswordConfirm").value();
                     if (TM.Gui.CurrentUser.checkPwdComplexity(password, passwordConfirm, "#errorMessage"))
+                    {
                         changePwd(currentPassword, password);
-                    $("#btnChangePwd").attr("disabled", "disabled");
+                        $("#btnChangePwd").attr("disabled", "disabled");
+                    } 
                 }
 
             if (typeof(changePwdDialog) != "undefined")


### PR DESCRIPTION
Hi There,
I'm requesting this pull to fix issue 384 Password Changed Successfully Dialog should not be clickable. 

In order to reproduce it and test it (and due the fact that locally this process is fast and you are not able to see if the button is enabled/disabled) I would recommend to use Fiddler and configure it to put a breakpoint on HTTP POST and on XMLHttpRequest.

See http://michaelhidalgocr.blogspot.com/ for details.
