### PR TITLE
Updating TM version so it points to 3.5.2

### DIFF
--- a/Source_Code/TM_WebSites/Website_3.5/Javascript/TM/Settings.js
+++ b/Source_Code/TM_WebSites/Website_3.5/Javascript/TM/Settings.js
@@ -1,6 +1,6 @@
 //TM Settings
-window.TM.tmVersion            = "TM 3.5.1";
-window.TM.ArticleTitle         = "TEAM Mentor 3.5.1";
+window.TM.tmVersion            = "TM 3.5.2";
+window.TM.ArticleTitle         = "TEAM Mentor 3.5.2";
 
 window.TM.tmWebServices        = '/Aspx_Pages/TM_WebServices.asmx/';
 window.TM.NotAuthorizedPage    = '/Html_Pages/Gui/Panels/AD_Non_Authorized_User.html';

--- a/TeamMentor/Publish/Website.3.5/Javascript/TM/Settings.js
+++ b/TeamMentor/Publish/Website.3.5/Javascript/TM/Settings.js
@@ -1,6 +1,6 @@
 //TM Settings
-window.TM.tmVersion            = "TM 3.5.1";
-window.TM.ArticleTitle         = "TEAM Mentor 3.5.1";
+window.TM.tmVersion            = "TM 3.5.2";
+window.TM.ArticleTitle         = "TEAM Mentor 3.5.2";
 
 window.TM.tmWebServices        = '/Aspx_Pages/TM_WebServices.asmx/';
 window.TM.NotAuthorizedPage    = '/Html_Pages/Gui/Panels/AD_Non_Authorized_User.html';


### PR DESCRIPTION
Another PR: This time TEAM Mentor version was updated to point to 3.5.2. No need to generate the release again as this is a JavaScript file that it's not compiled.
